### PR TITLE
test: fix snackbar close-button unit tests for store setters

### DIFF
--- a/__tests__/components/snackbar/SuccessSnackbar.spec.tsx
+++ b/__tests__/components/snackbar/SuccessSnackbar.spec.tsx
@@ -36,12 +36,23 @@ describe("SuccessSnackbar", () => {
   });
 
   it("Rerender invisibly if close button is clicked", async () => {
-    (useStore as unknown as Mock).mockReturnValue({
-      successMessage: "SuccessMessage",
+    // Given: Snackbar is visible with a success message
+    let successMessage = "SuccessMessage";
+    const setSuccessMessage = vi.fn((value: string) => {
+      successMessage = value;
     });
-    const { findByTestId, queryByText } = render(<SuccessSnackbar />);
+    (useStore as unknown as Mock).mockImplementation(() => ({
+      successMessage,
+      setSuccessMessage,
+    }));
+    const { findByTestId, queryByText, rerender } = render(<SuccessSnackbar />);
 
+    // When: User clicks the close control
     await userEvent.click(await findByTestId("success-snackbar-close"));
+
+    // Then: Store clear is requested and the message is hidden after re-render (as zustand would)
+    expect(setSuccessMessage).toHaveBeenCalledWith("");
+    rerender(<SuccessSnackbar />);
 
     await waitFor(() =>
       expect(queryByText("SuccessMessage")).not.toBeInTheDocument()

--- a/__tests__/components/snackbar/UserErrorSnackbar.spec.tsx
+++ b/__tests__/components/snackbar/UserErrorSnackbar.spec.tsx
@@ -36,12 +36,23 @@ describe("UserErrorSnackbar", () => {
   });
 
   it("Rerender invisibly if close button is clicked", async () => {
-    (useStore as unknown as Mock).mockReturnValue({
-      userErrorMessage: "UserErrorMessage",
+    // Given: Snackbar is visible with a user error message
+    let userErrorMessage = "UserErrorMessage";
+    const setUserErrorMessage = vi.fn((value: string) => {
+      userErrorMessage = value;
     });
-    const { findByTestId, queryByText } = render(<UserErrorSnackbar />);
+    (useStore as unknown as Mock).mockImplementation(() => ({
+      userErrorMessage,
+      setUserErrorMessage,
+    }));
+    const { findByTestId, queryByText, rerender } = render(<UserErrorSnackbar />);
 
+    // When: User clicks the close control
     await userEvent.click(await findByTestId("user-error-snackbar-close"));
+
+    // Then: Store clear is requested and the message is hidden after re-render (as zustand would)
+    expect(setUserErrorMessage).toHaveBeenCalledWith("");
+    rerender(<UserErrorSnackbar />);
 
     await waitFor(() =>
       expect(queryByText("UserErrorMessage")).not.toBeInTheDocument()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

The ESLint refactor in commit `9dc701f` updated `SuccessSnackbar` and `UserErrorSnackbar` so the close handler calls `setSuccessMessage("")` and `setUserErrorMessage("")`. The unit tests still mocked `useStore` without returning these setters, so clicking the close control threw `TypeError: setSuccessMessage is not a function` / `setUserErrorMessage is not a function` and the snackbar never disappeared in tests.

## Changes

- Add `vi.fn` mock setters in the close-button tests for both snackbar components.
- Use `mockImplementation` with mutable message state so each render reads the latest values.
- After the click, assert the setter was called with `""`, `rerender` the component (mirroring zustand re-subscription), and assert the message text is gone.

## Tests

- Command: `npx vitest run --coverage.enabled --coverage.reporter=json-summary` (same as the GitHub Actions Test step).
- Result: all 54 tests passed; no unhandled errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f83f746-93f9-4832-8b82-e259394be503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f83f746-93f9-4832-8b82-e259394be503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

