### PR TITLE
docs: add AGENTS.md with Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+PIU UCS Maker is a client-side-only React SPA for creating and playing Pump It Up UCS step charts. There is no backend, database, or external API dependency. See `CONTRIBUTING.md` for the canonical dev setup steps.
+
+### Development commands
+
+All commands are defined in `package.json` scripts:
+
+| Command | Purpose |
+|---|---|
+| `npm run dev` | Start Vite dev server (default port 5173) |
+| `npm run lint` | Run ESLint |
+| `npm run test` | Run Vitest (jsdom, coverage enabled, watch disabled) |
+| `npm run build` | TypeScript check + Vite production build |
+
+### Non-obvious notes
+
+- The project requires **Node.js 24.13.0**. Use `nvm use 24.13.0` (nvm is pre-installed). The update script handles installation of this version.
+- Vite dev server runs on port **5173** (not 3000 as stated in `CONTRIBUTING.md`). No port override is configured in `vite.config.ts`.
+- `npm run test` runs with `watch: false` and `maxWorkers: 1` by default (set in `vitest.config.ts`), so it exits after a single run.
+- Coverage thresholds are set at 80% for statements. Tests currently pass well above that (~98%).
+- The `vite.config.ts` has a custom alias for `daisyui` to force JS plugin import resolution for Tailwind CSS v4 compatibility.
+- `npm run build` uses base path `/PIUUCSMaker/` (for GitHub Pages deployment); the dev server uses `/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Add `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents.

## Changes

- Add `AGENTS.md` documenting:
  - Project overview (client-side-only React SPA, no backend/DB)
  - Development commands table (`npm run dev/lint/test/build`)
  - Non-obvious notes: Node.js 24.13.0 requirement, Vite port 5173 (not 3000), test config details, coverage thresholds, daisyUI alias workaround, build base path

## Tests

- Verified all development commands work correctly:
  - `npm run lint` — passes with no errors
  - `npm run test` — 54 tests pass, 98.3% statement coverage
  - `npm run build` — TypeScript check + Vite build succeeds
  - `npm run dev` — Vite dev server starts on port 5173
- Manually tested the application by creating a new UCS chart and placing notes

[demo_new_ucs_chart_creation.mp4](https://cursor.com/agents/bc-75781209-dbf1-4604-a263-098dc64ff3bf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_new_ucs_chart_creation.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75781209-dbf1-4604-a263-098dc64ff3bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75781209-dbf1-4604-a263-098dc64ff3bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

