### PR TITLE
fix: exclude unit tests from TypeScript build scope

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["__tests__", "src"],
+  "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Fixes the Build job failure in the Build and Deploy workflow after merging the unit test PR.

## Changes

- Remove `__tests__` from `tsconfig.json` `include` so `npm run build` (`tsc && vite build`) type-checks only `src`

## Technical details

The failure was not caused by Vite bundling test files into `dist`. `vite build` only bundles the app entry graph from `index.html` / `src`.

The Build step failed at **`tsc`** because `tsconfig.json` included `__tests__`, and newly added spec files have type errors when checked with the app TypeScript config (e.g. `showModal` on `HTMLElement`, `global` in tests, stricter `Note` types).

## Tests

- `npm run build` — passed
- `npm run test` — 190 tests passed
- `npm run lint` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dc4e9e1-0486-4538-b32e-ca03e48d17b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dc4e9e1-0486-4538-b32e-ca03e48d17b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

