### PR TITLE
chore: align tsconfig with TypeScript 6.0 defaults

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
 
@@ -13,6 +13,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "rootDir": "./src",
+    "types": [],
 
     /* Linting */
     "strict": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,7 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "types": ["node"]
   },
   "include": ["vite.config.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Aligns `tsconfig.json` and `tsconfig.node.json` with [TypeScript 6.0 breaking changes and new defaults](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html). The project dependency was already on `typescript@^6.0.3`; this PR completes the configuration migration recommended by the official release notes.

## Changes

- Set `rootDir` to `./src` in `tsconfig.json` (TS 6 now defaults `rootDir` to the directory containing `tsconfig.json`)
- Set `types` to `[]` in `tsconfig.json` and `["node"]` in `tsconfig.node.json` (TS 6 now defaults `types` to an empty array instead of loading all `@types/*` packages)
- Remove `DOM.Iterable` from `lib` because TS 6 includes iterable DOM APIs in the `DOM` lib
- Remove deprecated `allowSyntheticDefaultImports` from `tsconfig.node.json` (interop behavior is always enabled in TS 6)

## Technical details

- App sources under `src/` rely on explicit imports and `/// <reference types="vite/client" />`, so an empty `types` array avoids unintentionally pulling in global `@types/*` declarations and improves type-check performance.
- Node tooling configs (`vite.config.ts`, `vitest.config.ts`) explicitly opt into `@types/node` via `types: ["node"]`.

## Tests

- `npm run build` — passed (`tsc` + Vite production build)
- `npm run test` — passed (41 files, 190 tests, ~88% statement coverage)
- `npm run lint` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-997c6233-4c68-462f-bbc3-3b82f96c4340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-997c6233-4c68-462f-bbc3-3b82f96c4340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

